### PR TITLE
Docker: add dockerfile and README.md

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "coco-guest-components"]
+	path = coco-guest-components
+	url = git@github.com:confidential-containers/guest-components.git
+	branch = main

--- a/Dockerfile.ttrpc
+++ b/Dockerfile.ttrpc
@@ -1,0 +1,37 @@
+# Copyright (c) 2024 by Alibaba.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM rust:latest as builder
+
+WORKDIR /usr/src/guest-components
+COPY ./coco-guest-components .
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y protobuf-compiler
+
+# Build and install confidential-data-hub
+RUN cd confidential-data-hub/ && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm
+
+
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/attestation-agent"
+
+# TODO: gocryptfs will send log messages to the system's syslog service.
+#       And `SwitchToSyslog: Unix syslog delivery error` will occur.
+# Install ossfs, Gocryptofs and Runtime Dependencies
+RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
+    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    rm ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
+
+# Copy confidential-data-hub binary
+COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
+
+# Default Config File Path (/etc/confidential-data-hub.toml)
+VOLUME [ "/etc/" ]
+
+# Start confidential-data-hub with default unix sock (/run/confidential-containers/cdh.sock)
+CMD [ "confidential-data-hub" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,44 @@
-Confidential Data Hub (CDH) is a service running inside the guest to provide resource related APIs.
+Confidential Data Hub (aka CDH) is a service running inside the guest to provide resource related APIs.
 
-For more details, please visit [Confidential Data Hub](attestation-agent/README.md)
+This repository packages the CDH into an easy-to-use image.
 
-This repository packages the Confidential Data Hub (CDH) into an easy-to-use image.
+For more details, please visit [Confidential Data Hub](https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/README.md)
+
+# Build CDH Image
+
+CDH offers ttrpc interface.
+
+## Prerequisites
+
+- Ensure Docker is installed on your system
+
+## Build CDH Image
+
+``` shell
+# download code
+git clone --recurse-submodules \
+    https://github.com/inclavare-containers/confidential-data-hub.git && \
+    cd confidential-data-hub
+
+# build CDH image with ttrpc interface
+docker build -f ./Dockerfile.ttrpc -t cdh:ttrpc .
+```
+
+# Run CDH image with Docker
+
+## Prerequisites
+
+- Docker is installed on your host system
+- FUSE is supported and enabled on your host system
+- Installed CDH image
+
+## RUN CDH image
+
+Run image in the background.
+``` shell
+# TODO: use `--privileged` is dangerous, a better way should be applied
+#       to get access to `/dev/fuse`.
+docker run -d --privileged \
+    --device /dev/fuse \
+    --name cdh-ttrpc cdh:ttrpc
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+Confidential Data Hub (CDH) is a service running inside the guest to provide resource related APIs.
+
+For more details, please visit [Confidential Data Hub](attestation-agent/README.md)
+
+This repository packages the Confidential Data Hub (CDH) into an easy-to-use image.


### PR DESCRIPTION
1. Introduce CoCo/guest-components as a submodule.
2. Offer CDH images with ttrpc interface.
3. Provide a guide for image building and running in readme file.