### PR TITLE
Dockerization of CDH

### DIFF
--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -9,6 +9,7 @@ FROM rust:latest as builder
 # Define the default commit of source code
 # ARG CDH_COMMIT=ed809e5
 ARG CDH_COMMIT=HEAD
+ARG BUILD_FOR_TEST=false
 
 # Set the working directory inside the container
 WORKDIR /usr/src/guest-components
@@ -23,12 +24,17 @@ RUN apt-get install -y protobuf-compiler
 
 # Build and install confidential-data-hub with specific configurations
 RUN cd confidential-data-hub && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm RPC=grpc
-RUN cd confidential-data-hub/hub && cargo build --bin grpc-cdh-tool --features bin,grpc
+# RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
+#     cd confidential-data-hub/hub && \
+#     cargo build --bin grpc-cdh-tool --features bin,grpc --release; \
+# fi
 
 
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/attestation-agent"
+ARG BUILD_FOR_TEST=false
+
+LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/confidential-data-hub"
 
 # TODO: gocryptfs will send log messages to the system's syslog service.
 #       And `SwitchToSyslog: Unix syslog delivery error` will occur.
@@ -41,13 +47,15 @@ RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
 
 # Copy confidential-data-hub binary
 COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
-# Copy grpc-cdh-tool binary
-COPY --from=builder /usr/src/guest-components/target/debug/grpc-cdh-tool /usr/local/bin/grpc-cdh-tool
+# Copy grpc-cdh-tool binary (only for test)
+# COPY --from=builder /usr/src/guest-components/target/release/grpc-cdh-tool /usr/local/bin/grpc-cdh-tool
 
 # grpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
-RUN echo '{ \
+RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
+    echo '{ \
     "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" \
-}' > /etc/aa-offline_fs_kbc-resources.json
+    }' > /etc/aa-offline_fs_kbc-resources.json; \
+fi
 
 # Default Config File Path (/etc/confidential-data-hub.toml)
 VOLUME [ "/etc/" ]

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -7,9 +7,7 @@ FROM rust:latest as builder
 
 # The list of build argument with docker build --build-arg NAME=VALUE
 # Define the default commit of source code
-# ARG CDH_COMMIT=ed809e5
 ARG CDH_COMMIT=HEAD
-ARG BUILD_FOR_TEST=false
 
 # Set the working directory inside the container
 WORKDIR /usr/src/guest-components
@@ -34,24 +32,16 @@ RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
 
 FROM ubuntu:22.04
 
-ARG BUILD_FOR_TEST=false
 
 LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/confidential-data-hub"
 
 # Copy ossfs
 COPY --from=builder /usr/local/bin/ossfs /usr/local/bin/ossfs
 # Copy gocryptfs
-COPY --from=builder /usr/bin/gocryptfs /usr/bin/gocryptfs
-RUN ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
+COPY --from=builder /usr/bin/gocryptfs /usr/local/bin/gocryptfs
 # Copy confidential-data-hub binary
 COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
 
-# grpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
-RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
-    echo '{ \
-    "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" \
-    }' > /etc/aa-offline_fs_kbc-resources.json; \
-fi
 
 # Default Config File Path (/etc/confidential-data-hub.toml)
 VOLUME [ "/etc/confidential-data-hub.toml" ]

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -24,10 +24,12 @@ RUN apt-get install -y protobuf-compiler
 
 # Build and install confidential-data-hub with specific configurations
 RUN cd confidential-data-hub && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm RPC=grpc
-# RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
-#     cd confidential-data-hub/hub && \
-#     cargo build --bin grpc-cdh-tool --features bin,grpc --release; \
-# fi
+
+# Install ossfs, Gocryptofs and Runtime Dependencies
+RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
+    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    rm ossfs_1.91.2_ubuntu22.04_amd64.deb 
 
 
 FROM ubuntu:22.04
@@ -36,19 +38,13 @@ ARG BUILD_FOR_TEST=false
 
 LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/confidential-data-hub"
 
-# TODO: gocryptfs will send log messages to the system's syslog service.
-#       And `SwitchToSyslog: Unix syslog delivery error` will occur.
-# Install ossfs, Gocryptofs and Runtime Dependencies
-RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
-    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
-    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
-    rm ossfs_1.91.2_ubuntu22.04_amd64.deb && \
-    ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
-
+# Copy ossfs
+COPY --from=builder /usr/local/bin/ossfs /usr/local/bin/ossfs
+# Copy gocryptfs
+COPY --from=builder /usr/bin/gocryptfs /usr/bin/gocryptfs
+RUN ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
 # Copy confidential-data-hub binary
 COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
-# Copy grpc-cdh-tool binary (only for test)
-# COPY --from=builder /usr/src/guest-components/target/release/grpc-cdh-tool /usr/local/bin/grpc-cdh-tool
 
 # grpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
@@ -58,9 +54,9 @@ RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
 fi
 
 # Default Config File Path (/etc/confidential-data-hub.toml)
-VOLUME [ "/etc/" ]
+VOLUME [ "/etc/confidential-data-hub.toml" ]
 
-# Start confidential-data-hub with default unix sock (/run/confidential-containers/cdh.sock)
+# Start confidential-data-hub listening to request: 127.0.0.1:50000
 CMD [ "confidential-data-hub" ]
 
 EXPOSE 50000

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,0 +1,58 @@
+# Copyright (c) 2024 by Alibaba.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Use the official Rust image as the base image
+FROM rust:latest as builder
+
+# The list of build argument with docker build --build-arg NAME=VALUE
+# Define the default commit of source code
+# ARG CDH_COMMIT=ed809e5
+ARG CDH_COMMIT=HEAD
+
+# Set the working directory inside the container
+WORKDIR /usr/src/guest-components
+
+# Clone the specific commit from the GitHub repository
+RUN apt-get update && apt-get install -y git \
+    && git clone https://github.com/confidential-containers/guest-components.git . \
+    && git checkout ${CDH_COMMIT}
+
+# Install additional build dependencies
+RUN apt-get install -y protobuf-compiler
+
+# Build and install confidential-data-hub with specific configurations
+RUN cd confidential-data-hub && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm RPC=grpc
+RUN cd confidential-data-hub/hub && cargo build --bin grpc-cdh-tool --features bin,grpc
+
+
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/attestation-agent"
+
+# TODO: gocryptfs will send log messages to the system's syslog service.
+#       And `SwitchToSyslog: Unix syslog delivery error` will occur.
+# Install ossfs, Gocryptofs and Runtime Dependencies
+RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
+    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    rm ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
+
+# Copy confidential-data-hub binary
+COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
+# Copy grpc-cdh-tool binary
+COPY --from=builder /usr/src/guest-components/target/debug/grpc-cdh-tool /usr/local/bin/grpc-cdh-tool
+
+# grpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
+RUN echo '{ \
+    "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" \
+}' > /etc/aa-offline_fs_kbc-resources.json
+
+# Default Config File Path (/etc/confidential-data-hub.toml)
+VOLUME [ "/etc/" ]
+
+# Start confidential-data-hub with default unix sock (/run/confidential-containers/cdh.sock)
+CMD [ "confidential-data-hub" ]
+
+EXPOSE 50000

--- a/Dockerfile.ttrpc
+++ b/Dockerfile.ttrpc
@@ -24,10 +24,12 @@ RUN apt-get install -y protobuf-compiler
 
 # Build and install confidential-data-hub with specific configurations
 RUN cd confidential-data-hub && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm RPC=ttrpc
-# RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
-#     cd confidential-data-hub/hub && \
-#     cargo build --bin ttrpc-cdh-tool --features bin,ttrpc --release; \
-# fi
+
+# Install ossfs, Gocryptofs and Runtime Dependencies
+RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
+    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    rm ossfs_1.91.2_ubuntu22.04_amd64.deb 
 
 
 
@@ -37,19 +39,13 @@ ARG BUILD_FOR_TEST=false
 
 LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/confidential-data-hub"
 
-# TODO: gocryptfs will send log messages to the system's syslog service.
-#       And `SwitchToSyslog: Unix syslog delivery error` will occur.
-# Install ossfs, Gocryptofs and Runtime Dependencies
-RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
-    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
-    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
-    rm ossfs_1.91.2_ubuntu22.04_amd64.deb && \
-    ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
-
+# Copy ossfs
+COPY --from=builder /usr/local/bin/ossfs /usr/local/bin/ossfs
+# Copy gocryptfs
+COPY --from=builder /usr/bin/gocryptfs /usr/bin/gocryptfs
+RUN ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
 # Copy confidential-data-hub binary
 COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
-# Copy ttrpc-cdh-tool binary (only for test)
-# COPY --from=builder /usr/src/guest-components/target/release/ttrpc-cdh-tool /usr/local/bin/ttrpc-cdh-tool
 
 # ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
@@ -59,7 +55,7 @@ RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
 fi
 
 # Default Config File Path (/etc/confidential-data-hub.toml)
-VOLUME [ "/etc/" ]
+VOLUME [ "/etc/confidential-data-hub.toml" ]
 
 # Start confidential-data-hub with default unix sock (/run/confidential-containers/cdh.sock)
 CMD [ "confidential-data-hub" ]

--- a/Dockerfile.ttrpc
+++ b/Dockerfile.ttrpc
@@ -9,6 +9,7 @@ FROM rust:latest as builder
 # Define the default commit of source code
 # ARG CDH_COMMIT=ed809e5
 ARG CDH_COMMIT=HEAD
+ARG BUILD_FOR_TEST=false
 
 # Set the working directory inside the container
 WORKDIR /usr/src/guest-components
@@ -23,13 +24,18 @@ RUN apt-get install -y protobuf-compiler
 
 # Build and install confidential-data-hub with specific configurations
 RUN cd confidential-data-hub && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm RPC=ttrpc
-RUN cd confidential-data-hub/hub && cargo build --bin ttrpc-cdh-tool --features bin,ttrpc
+# RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
+#     cd confidential-data-hub/hub && \
+#     cargo build --bin ttrpc-cdh-tool --features bin,ttrpc --release; \
+# fi
 
 
 
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/attestation-agent"
+ARG BUILD_FOR_TEST=false
+
+LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/confidential-data-hub"
 
 # TODO: gocryptfs will send log messages to the system's syslog service.
 #       And `SwitchToSyslog: Unix syslog delivery error` will occur.
@@ -42,13 +48,15 @@ RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
 
 # Copy confidential-data-hub binary
 COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
-# Copy ttrpc-cdh-tool binary
-COPY --from=builder /usr/src/guest-components/target/debug/ttrpc-cdh-tool /usr/local/bin/ttrpc-cdh-tool
+# Copy ttrpc-cdh-tool binary (only for test)
+# COPY --from=builder /usr/src/guest-components/target/release/ttrpc-cdh-tool /usr/local/bin/ttrpc-cdh-tool
 
 # ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
-RUN echo '{ \
+RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
+    echo '{ \
     "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" \
-}' > /etc/aa-offline_fs_kbc-resources.json
+    }' > /etc/aa-offline_fs_kbc-resources.json; \
+fi
 
 # Default Config File Path (/etc/confidential-data-hub.toml)
 VOLUME [ "/etc/" ]

--- a/Dockerfile.ttrpc
+++ b/Dockerfile.ttrpc
@@ -7,9 +7,7 @@ FROM rust:latest as builder
 
 # The list of build argument with docker build --build-arg NAME=VALUE
 # Define the default commit of source code
-# ARG CDH_COMMIT=ed809e5
 ARG CDH_COMMIT=HEAD
-ARG BUILD_FOR_TEST=false
 
 # Set the working directory inside the container
 WORKDIR /usr/src/guest-components
@@ -32,27 +30,18 @@ RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
     rm ossfs_1.91.2_ubuntu22.04_amd64.deb 
 
 
-
 FROM ubuntu:22.04
 
-ARG BUILD_FOR_TEST=false
 
 LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/confidential-data-hub"
 
 # Copy ossfs
 COPY --from=builder /usr/local/bin/ossfs /usr/local/bin/ossfs
 # Copy gocryptfs
-COPY --from=builder /usr/bin/gocryptfs /usr/bin/gocryptfs
-RUN ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
+COPY --from=builder /usr/bin/gocryptfs /usr/local/bin/gocryptfs
 # Copy confidential-data-hub binary
 COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
 
-# ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
-RUN if [ "$BUILD_FOR_TEST" = "true" ]; then \
-    echo '{ \
-    "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" \
-    }' > /etc/aa-offline_fs_kbc-resources.json; \
-fi
 
 # Default Config File Path (/etc/confidential-data-hub.toml)
 VOLUME [ "/etc/confidential-data-hub.toml" ]

--- a/Dockerfile.ttrpc
+++ b/Dockerfile.ttrpc
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 by Alibaba.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Use the official Rust image as the base image
+FROM rust:latest as builder
+
+# The list of build argument with docker build --build-arg NAME=VALUE
+# Define the default commit of source code
+# ARG CDH_COMMIT=ed809e5
+ARG CDH_COMMIT=HEAD
+
+# Set the working directory inside the container
+WORKDIR /usr/src/guest-components
+
+# Clone the specific commit from the GitHub repository
+RUN apt-get update && apt-get install -y git \
+    && git clone https://github.com/confidential-containers/guest-components.git . \
+    && git checkout ${CDH_COMMIT}
+
+# Install additional build dependencies
+RUN apt-get install -y protobuf-compiler
+
+# Build and install confidential-data-hub with specific configurations
+RUN cd confidential-data-hub && make RESOURCE_PROVIDER=kbs,sev KMS_PROVIDER=aliyun,ehsm RPC=ttrpc
+RUN cd confidential-data-hub/hub && cargo build --bin ttrpc-cdh-tool --features bin,ttrpc
+
+
+
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.source="https://github.com/inclavare-containers/attestation-agent"
+
+# TODO: gocryptfs will send log messages to the system's syslog service.
+#       And `SwitchToSyslog: Unix syslog delivery error` will occur.
+# Install ossfs, Gocryptofs and Runtime Dependencies
+RUN apt-get update && apt-get install -y wget gdebi-core fuse gocryptfs && \
+    wget https://gosspublic.alicdn.com/ossfs/ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    gdebi -n ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    rm ossfs_1.91.2_ubuntu22.04_amd64.deb && \
+    ln -s /usr/bin/gocryptfs /usr/local/bin/gocryptfs
+
+# Copy confidential-data-hub binary
+COPY --from=builder /usr/src/guest-components/target/x86_64-unknown-linux-gnu/release/confidential-data-hub /usr/local/bin/confidential-data-hub
+# Copy ttrpc-cdh-tool binary
+COPY --from=builder /usr/src/guest-components/target/debug/ttrpc-cdh-tool /usr/local/bin/ttrpc-cdh-tool
+
+# ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
+RUN echo '{ \
+    "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" \
+}' > /etc/aa-offline_fs_kbc-resources.json
+
+# Default Config File Path (/etc/confidential-data-hub.toml)
+VOLUME [ "/etc/" ]
+
+# Start confidential-data-hub with default unix sock (/run/confidential-containers/cdh.sock)
+CMD [ "confidential-data-hub" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+CDH_COMMIT ?=
+
+default_cdh_commit := ed809e5
+
+ifeq ($(CDH_COMMIT),)
+    cdh_commit := $(default_cdh_commit)
+else
+    cdh_commit := $(CDH_COMMIT)
+endif
+
+no_cache :=
+ifneq ($(findstring $(cdh_commit),$(default_cdh_commit)),$(default_cdh_commit))
+    no_cache := --no-cache
+endif
+
+.PHONE: all build build-image-grpc build-image-ttrpc
+
+all: help
+
+help: ## Print this help information
+	@awk -F ':|##' '/^[^\t].+?:.*?##/ { printf "\033[36m%-20s\033[0m", $$1; for (i=3; i<=NF; i++) printf " %s", $$i; printf "\n" }' $(MAKEFILE_LIST)
+
+build: build-grpc build-ttrpc ## Build the confidential-data-hub images with CDH_COMMIT to set the commit to build
+
+build-grpc: ## Build the confidential-data-hub grpc image with CDH_COMMIT to set the commit to build
+	@echo "\033[1;32mBuilding the confidential-data-hub for grpc with the commit $(cdh_commit) ...\033[0m"
+	docker build \
+	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
+	    -f ./Dockerfile.grpc -t confidential-data-hub:grpc .
+
+build-ttrpc: ## Build the confidential-data-hub ttrpc image with CDH_COMMIT to set the commit to build
+	@echo "\033[1;32mBuilding the confidential-data-hub for ttrpc with the commit $(cdh_commit) ...\033[0m"
+	docker build \
+	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
+	    -f ./Dockerfile.ttrpc -t confidential-data-hub:ttrpc .

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,4 @@
-CDH_COMMIT ?=
-
-default_cdh_commit := ed809e5
-
-ifeq ($(CDH_COMMIT),)
-    cdh_commit := $(default_cdh_commit)
-else
-    cdh_commit := $(CDH_COMMIT)
-endif
-
-no_cache :=
-ifneq ($(findstring $(cdh_commit),$(default_cdh_commit)),$(default_cdh_commit))
-    no_cache := --no-cache
-endif
+CDH_COMMIT ?= ed809e5
 
 .PHONE: all build build-image-grpc build-image-ttrpc
 
@@ -25,11 +12,11 @@ build: build-grpc build-ttrpc ## Build the confidential-data-hub images with CDH
 build-grpc: ## Build the confidential-data-hub grpc image with CDH_COMMIT to set the commit to build
 	@echo "\033[1;32mBuilding the confidential-data-hub for grpc with the commit $(cdh_commit) ...\033[0m"
 	docker build \
-	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
+	    --no-cache --build-arg CDH_COMMIT=$(CDH_COMMIT) \
 	    -f ./Dockerfile.grpc -t confidential-data-hub:grpc .
 
 build-ttrpc: ## Build the confidential-data-hub ttrpc image with CDH_COMMIT to set the commit to build
 	@echo "\033[1;32mBuilding the confidential-data-hub for ttrpc with the commit $(cdh_commit) ...\033[0m"
 	docker build \
-	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
+	    --no-cache --build-arg CDH_COMMIT=$(CDH_COMMIT) \
 	    -f ./Dockerfile.ttrpc -t confidential-data-hub:ttrpc .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CDH_COMMIT ?=
 
+TEST ?= false
+
 default_cdh_commit := ed809e5
 
 ifeq ($(CDH_COMMIT),)
@@ -25,11 +27,11 @@ build: build-grpc build-ttrpc ## Build the confidential-data-hub images with CDH
 build-grpc: ## Build the confidential-data-hub grpc image with CDH_COMMIT to set the commit to build
 	@echo "\033[1;32mBuilding the confidential-data-hub for grpc with the commit $(cdh_commit) ...\033[0m"
 	docker build \
-	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
+	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) --build-arg BUILD_FOR_TEST=$(TEST)\
 	    -f ./Dockerfile.grpc -t confidential-data-hub:grpc .
 
 build-ttrpc: ## Build the confidential-data-hub ttrpc image with CDH_COMMIT to set the commit to build
 	@echo "\033[1;32mBuilding the confidential-data-hub for ttrpc with the commit $(cdh_commit) ...\033[0m"
 	docker build \
-	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
+	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) --build-arg BUILD_FOR_TEST=$(TEST)\
 	    -f ./Dockerfile.ttrpc -t confidential-data-hub:ttrpc .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 CDH_COMMIT ?=
 
-TEST ?= false
-
 default_cdh_commit := ed809e5
 
 ifeq ($(CDH_COMMIT),)
@@ -27,11 +25,11 @@ build: build-grpc build-ttrpc ## Build the confidential-data-hub images with CDH
 build-grpc: ## Build the confidential-data-hub grpc image with CDH_COMMIT to set the commit to build
 	@echo "\033[1;32mBuilding the confidential-data-hub for grpc with the commit $(cdh_commit) ...\033[0m"
 	docker build \
-	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) --build-arg BUILD_FOR_TEST=$(TEST)\
+	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
 	    -f ./Dockerfile.grpc -t confidential-data-hub:grpc .
 
 build-ttrpc: ## Build the confidential-data-hub ttrpc image with CDH_COMMIT to set the commit to build
 	@echo "\033[1;32mBuilding the confidential-data-hub for ttrpc with the commit $(cdh_commit) ...\033[0m"
 	docker build \
-	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) --build-arg BUILD_FOR_TEST=$(TEST)\
+	    $(no_cache) --build-arg CDH_COMMIT=$(cdh_commit) \
 	    -f ./Dockerfile.ttrpc -t confidential-data-hub:ttrpc .

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Confidential Data Hub (`CDH`) is a service running inside the guest to provide resource related APIs.
 
-For more information, please visit the project's [repository](https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/README.md).
+For more information, please visit the project's [repository](https://github.com/confidential-containers/guest-components/tree/ed809e5ea632055b62751de31191023290104882/confidential-data-hub/README.md).
 
 ## Build CDH Images
 
@@ -36,13 +36,38 @@ Depending on whether you are using the gRPC or ttrpc interface, running the CDH 
 ### Run CDH image with gRPC interface
 
 ```shell
-docker run -d \
+docker run -d --network host \
     --name cdh-grpc confidential-data-hub:grpc
 ```
 
 ### Run CDH image with ttrpc interface
 
 ```shell
-docker run -d \
+docker run -d -v /run/confidential-containers:/run/confidential-containers \
     --name cdh-ttrpc confidential-data-hub:ttrpc
+```
+
+## Test Built Images
+
+### Prerequisites
+
+- Ensure Docker is installed on your system
+- Ensure [Client Tools](https://github.com/confidential-containers/guest-components/tree/ed809e5ea632055b62751de31191023290104882/confidential-data-hub#client-tool) are installed on your host system
+
+### Run Tests
+
+```shell
+# grpc
+# terminal 1
+make build-grpc TEST=true
+docker run --rm --network host confidential-data-hub:grpc
+# terminal 2
+grpc-cdh-tool get-resource --resource-uri kbs://127.0.0.1:50000/default/key/1
+
+# ttrpc
+# terminal 1
+make build-ttrpc TEST=true
+docker run --rm -v /run/confidential-containers:/run/confidential-containers confidential-data-hub:ttrpc
+# terminal 2
+ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ grpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 # create resource file for test
 echo '{ "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" }' > /etc/aa-offline_fs_kbc-resources.json
 make build-ttrpc
-docker run --rm -v /run/confidential-containers:/run/confidential-containers confidential-data-hub:ttrpc
+docker run --rm -v /etc/aa-offline_fs_kbc-resources.json:/etc/aa-offline_fs_kbc-resources.json -v /run/confidential-containers:/run/confidential-containers confidential-data-hub:ttrpc
 # open terminal 2
 ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 ```

--- a/README.md
+++ b/README.md
@@ -57,17 +57,21 @@ docker run -d -v /run/confidential-containers:/run/confidential-containers \
 ### Run Tests
 
 ```shell
-# grpc
-# terminal 1
-make build-grpc TEST=true
-docker run --rm --network host confidential-data-hub:grpc
-# terminal 2
-grpc-cdh-tool get-resource --resource-uri kbs://127.0.0.1:50000/default/key/1
+# test cdh-grpc
+# open terminal 1
+# create resource file for test
+echo '{ "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" }' > /etc/aa-offline_fs_kbc-resources.json
+make build-grpc
+docker run --rm --network host -v /etc/aa-offline_fs_kbc-resources.json:/etc/aa-offline_fs_kbc-resources.json confidential-data-hub:grpc
+# open terminal 2
+grpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 
-# ttrpc
-# terminal 1
-make build-ttrpc TEST=true
+# test cdh-ttrpc
+# open terminal 1
+# create resource file for test
+echo '{ "default/key/1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=" }' > /etc/aa-offline_fs_kbc-resources.json
+make build-ttrpc
 docker run --rm -v /run/confidential-containers:/run/confidential-containers confidential-data-hub:ttrpc
-# terminal 2
+# open terminal 2
 ttrpc-cdh-tool get-resource --resource-uri kbs:///default/key/1
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+
+# Confidential-Data-Hub (CDH)
+
+Confidential Data Hub (`CDH`) is a service running inside the guest to provide resource related APIs.
+
+For more information, please visit the project's [repository](https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/README.md).
+
+## Build CDH Images
+
+CDH supports two kinds of interfaces: gRPC and ttrpc. Please select the corresponding Dockerfile to build your CDH image.
+
+### Prerequisites
+
+- Ensure Docker is installed on your system
+
+### Build Image
+
+```shell
+# Clone the repository and prepare for building
+git clone https://github.com/jingyao-zhang/docker-confidential-data-hub && \
+    cd docker-confidential-data-hub
+
+# Build CDH image with gRPC interface
+make build-grpc
+
+# Build CDH image with ttrpc interface
+make build-ttrpc
+```
+
+To build a specific commit of CDH, set the `CDH_COMMIT` environment variable before building. Run `make help` for full help information.
+
+## Run CDH Images
+
+Depending on whether you are using the gRPC or ttrpc interface, running the CDH image varies slightly.
+
+### Run CDH image with gRPC interface
+
+```shell
+docker run -d \
+    --name cdh-grpc confidential-data-hub:grpc
+```
+
+### Run CDH image with ttrpc interface
+
+```shell
+docker run -d \
+    --name cdh-ttrpc confidential-data-hub:ttrpc
+```


### PR DESCRIPTION
1. Provide `Dockerfiles` for [Confidential-Data-Hub](https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/README.md) with `ttrpc` and `grpc` interface.
2. Provide `makefile` for building.
3. Provide `README` for usage.